### PR TITLE
Timeline - Force cropping period to be within the current year

### DIFF
--- a/src/helper/plan.js
+++ b/src/helper/plan.js
@@ -4,30 +4,37 @@ import { readType } from "./localStorage";
 import { getGermanTranslations } from "./l10n";
 const groupId = (crop, period) => `${crop.id} - ${period.id}`;
 
-export const generate = crops => {
+export const generate = (crops) => {
   let allGroups = [];
   let allItems = [];
-  crops.forEach(crop => {
+  crops.forEach((crop) => {
     if ("periods" in crop) {
       const selectedGardenType = readType();
 
       const periodsForSelectedGardenType = crop.periods.filter(
-        period => period.location === selectedGardenType.id
+        (period) => period.location === selectedGardenType.id
       );
 
-      const groupsForCropPeriod = periodsForSelectedGardenType.map(period => ({
-        id: groupId(crop, period),
-        title: `${crop.name} - ${getGermanTranslations[period.workflow]}`,
-        image: "image" in crop ? crop.image : undefined
-      }));
+      const groupsForCropPeriod = periodsForSelectedGardenType.map(
+        (period) => ({
+          id: groupId(crop, period),
+          title: `${crop.name} - ${getGermanTranslations[period.workflow]}`,
+          image: "image" in crop ? crop.image : undefined,
+        })
+      );
 
-      const itemsForCropPeriod = periodsForSelectedGardenType.map(period => {
+      const itemsForCropPeriod = periodsForSelectedGardenType.map((period) => {
+        const start_time = moment(period.begin);
+        const end_time = moment(period.end);
+        
         return {
           group: groupId(crop, period),
           title: getGermanTranslations[period.workflow],
           id: Math.random(),
-          start_time: moment(period.begin),
-          end_time: moment(period.end)
+          // Change year to current year
+          start_time: start_time.year(moment().year()),
+          // Change year to current year
+          end_time: end_time.year(moment().year()),
         };
       });
       allGroups = allGroups.concat(groupsForCropPeriod);


### PR DESCRIPTION
The data endpoints might provide cropping periods in the past years. Actually the year isn't important
at all. Thus we force the year to be always the current one to work fine with the timeline component.